### PR TITLE
breaking change to sdk, using new base urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,17 @@ Full documentation for this sdk can be found in our [Agility Fetch JS SDK Refere
 Coming soon...
 
 
+## Contributing
+If you would like to contribute to this SDK, you can fork the repository and submit a pull request. We'd love to include your updates.
+
+### Running the Tests
+An essential part of contributing to this SDK is adding and running unit tests to ensure the stability of the project.
+```
+> npm run test
+```
+
+
+
 
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agility/content-fetch",
-  "version": "0.2.5",
+  "version": "0.3.0",
   "description": "JavaScript library for the Agility Fetch API (node and browser)",
   "main": "dist/agility-content-fetch.node.js",
   "scripts": {

--- a/src/api-client.js
+++ b/src/api-client.js
@@ -7,8 +7,8 @@ import getContentList from './methods/getContentList'
 import getPage from './methods/getPage'
 
 const defaultConfig = {
-    fetchBaseUrl: 'https://g5s2z5b3.stackpathcdn.com',
-    previewBaseUrl: 'https://e5q8t3m6.stackpathcdn.com',
+    fetchBaseUrl: 'https://fetch.agilitycms.cloud',
+    previewBaseUrl: 'https://preview.agilitycms.cloud',
     baseUrl: null,
     isPreview: false,
     instanceID: null,

--- a/test/apiClients.config.js
+++ b/test/apiClients.config.js
@@ -1,9 +1,9 @@
 import agility from '../src/content-fetch'
 
-//Agiliy Instance = 'Headless Integration Testing'
+// Agiliy Instance = 'Headless Integration Testing'
 const instanceID = 'c741222b-1080-45f6-9a7f-982381c5a485';
-const accessTokenFetch = 'mn16Ui.17dc2f94908b113a6eb0869681f5cfa77df6dbd181d22943b64bf8ef728b6c5c';
-const accessTokenPreview = 'tR95Pt.cc81dfbe0726263d5d9618b21f49fe33830e5449395820ade1cad3ce89d22ed8';
+const accessTokenFetch = 'mn16Ui.a70c306e57eb682bf6dc5e42325dd77b06ddde33f5a8e46530e680ad334c7e6d';
+const accessTokenPreview = 'tR95Pt.3c66512540fbbb00944602c9be1ca913fe3d83f41fbec172fa005ef10d9d1273';
 
 function createApiClient() {
     var api = agility.getApi({


### PR DESCRIPTION
**New**: https://fetch.agilitycms.cloud
**New**: https://preview.agilitycms.cloud

Removed all references to stackpath urls.