### PR TITLE
changed sort property on sort content list to content id

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,11 @@
     "url": "git+https://github.com/agility/agility-content-fetch-js-sdk.git"
   },
   "author": "Agility CMS",
-  "contributors": ["James Vidler", "Joel Varty", "Joshua Isaac"],
+  "contributors": [
+    "James Vidler",
+    "Joel Varty",
+    "Joshua Isaac"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/agility/agility-content-fetch-js-sdk/issues"

--- a/test/getContentList.tests.js
+++ b/test/getContentList.tests.js
@@ -193,7 +193,7 @@ describe('getContentList:', function() {
         api.getContentList({
             referenceName: 'posts',
             locale: 'en-us',
-            sort: 'properties.versionID',
+            sort: 'properties.contentID',
             direction: api.types.SortDirections.DESC
         })
         .then(function(contentList) {


### PR DESCRIPTION
In the sort content list on live test, we were sorting the property versiodID and then comparing the contentIDs. I changed the sort property to contentID