### PR TITLE
new filter string property on getContentList

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agility/content-fetch",
-  "version": "2.0.6",
-  "description": "JavaScript library for the Agility Fetch API (node and browser)",
+  "version": "2.0.7",
+  "description": "JS/TS library for the Agility Fetch API",
   "repository": {
     "type": "git",
     "url": "https://github.com/agility/agility-content-fetch-js-sdk.git"

--- a/src/methods/getContentList.ts
+++ b/src/methods/getContentList.ts
@@ -66,15 +66,62 @@ import { TypeError } from '../types/errors/Errors';
 */
 
 export interface ContentListRequestParams {
+
+	/**
+	 * The unique reference name of the content list you wish to retrieve in the specified language.
+	 */
 	referenceName: string;
+
+	/**
+	 * The locale code of the content you want to retrieve.
+	 */
 	locale?: string;
+
+	/**
+	 * The language code of the content you want to retrieve.
+	 * DEPRECATED: Use locale instead.
+	 */
 	languageCode?: string;
+
+	/**
+	 * The depth, representing the levels in which you want linked content auto-resolved.
+	 */
 	contentLinkDepth?: number;
+
+	/**
+	 * Whether or not to expand entire linked content references, includings lists and items that are rendered in the CMS as Grid or Link.
+	 */
 	expandAllContentLinks?: boolean;
+
+	/**
+	 * The number of items to retrieve in this request. Default is 10. Maximum allowed is 250.
+	 */
 	take?: number;
+
+	/**
+	 * The number of items to skip from the list. Used for implementing pagination.
+	 */
 	skip?: number;
+
+	/**
+	 * The field to sort the results by. Example fields.title or properties.modified.
+	 */
 	sort?: string;
+
+	/**
+	 * The direction to sort the results by.
+	 */
 	direction?: SortDirection;
+
+	/**
+	 * Option: you can provide a plain text filter string as opposed to an array of filters.  This is useful if you have brackets in your filter expression.
+	 */
+	filterString?: string;
+
+	/**
+	 * Provide an array of filters as opposed to a plain text filter string.
+	 * If you need advanced filering with brackets, use the filterString operator.
+	 */
 	filters?: Array<Filter>;
 	filtersLogicOperator?:
 	FilterLogicOperator;
@@ -90,7 +137,7 @@ function getContentList(this: ApiClientInstance, requestParams: ContentListReque
 	requestParams = { ...defaultParams, ...requestParams };
 
 	const req = {
-		url: buildPathUrl("list", requestParams.referenceName, requestParams.skip, requestParams.take, requestParams.sort, requestParams.direction, requestParams.filters, requestParams.filtersLogicOperator, requestParams.contentLinkDepth, requestParams.expandAllContentLinks),
+		url: buildPathUrl("list", requestParams.referenceName, requestParams.skip, requestParams.take, requestParams.sort, requestParams.direction, requestParams.filters, requestParams.filtersLogicOperator, requestParams.filterString, requestParams.contentLinkDepth, requestParams.expandAllContentLinks),
 		method: 'get',
 		baseURL: buildRequestUrlPath(this.config, requestParams.locale ? requestParams.locale : requestParams.languageCode),
 		headers: buildAuthHeader(this.config),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,8 +43,9 @@ function buildRequestUrlPath(config, locale) {
 	return urlPath;
 }
 
-function buildPathUrl(contentType, referenceName, skip, take, sort, direction, filters, filtersLogicOperator, contentLinkDepth, expandAllContentLinks) {
+function buildPathUrl(contentType, referenceName, skip, take, sort, direction, filters, filtersLogicOperator, filterString, contentLinkDepth, expandAllContentLinks) {
 	let url = `/${contentType}/${referenceName}?contentLinkDepth=${contentLinkDepth}&`;
+
 	filtersLogicOperator = filtersLogicOperator ? ` ${filtersLogicOperator} ` : ' AND ';
 
 	if (sort) {
@@ -63,12 +64,16 @@ function buildPathUrl(contentType, referenceName, skip, take, sort, direction, f
 	}
 
 	if (filters && filters.length > 0) {
+		//use the filters array if we have it
 		url += 'filter='
 		for (let i = 0; i < filters.length; i++) {
 			let filter = filters[i];
 			url += `${filter.property}[${filter.operator}]${filter.value}` + (i < filters.length - 1 ? filtersLogicOperator : '');
 		}
 		url += '&';
+	} else if (filterString) {
+		//use the filterString if we have it and no array has been pased
+		url += `filter=${filterString}&`;
 	}
 
 	if (expandAllContentLinks) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -73,7 +73,7 @@ function buildPathUrl(contentType, referenceName, skip, take, sort, direction, f
 		url += '&';
 	} else if (filterString) {
 		//use the filterString if we have it and no array has been pased
-		url += `filter=${filterString}&`;
+		url += `filter=${encodeURIComponent(filterString)}&`;
 	}
 
 	if (expandAllContentLinks) {

--- a/test/apiClients.config.ts
+++ b/test/apiClients.config.ts
@@ -25,3 +25,4 @@ export function createPreviewApiClient() {
         baseUrl: `https://api-dev.aglty.io/${guid}`
     });
     return api;
+}

--- a/test/getContentItem.tests.ts
+++ b/test/getContentItem.tests.ts
@@ -95,3 +95,4 @@ describe('getContentItem:', () => {
         });
         expect(Array.isArray(contentItem.fields.posts)).toBe(false);
     });
+});

--- a/test/getContentList.tests.ts
+++ b/test/getContentList.tests.ts
@@ -272,6 +272,8 @@ describe('getContentList:', () => {
 		expect(contentList.items[3].contentID).toBe(15);
 	});
 
+
+
 	it('should filter the content list in live mode with AND operator between filters', async () => {
 		const api = createApiClient();
 		const contentList = await api.getContentList({
@@ -285,6 +287,22 @@ describe('getContentList:', () => {
 		});
 		expect(contentList.items[0].contentID).toBe(16);
 		expect(contentList.items.length).toBe(1);
+	});
+
+	it('should filter the content list using a string in live mode ', async () => {
+		const api = createApiClient();
+		const contentList = await api.getContentList({
+			referenceName: 'posts',
+			locale: 'en-us',
+			filterString: `contentID[eq]15 or properties.referenceName[like]"posts"`
+			// [
+			// 	{ property: 'contentID', operator: api.types.FilterOperators.EQUAL_TO, value: '15' },
+			// 	{ property: 'properties.referenceName', operator: api.types.FilterOperators.LIKE, value: 'posts' },
+			// ],
+			// filtersLogicOperator: api.types.FilterLogicOperators.OR,
+		});
+		expect(contentList.items[0].contentID).toBe(16);
+		expect(contentList.items[3].contentID).toBe(15);
 	});
 
 	it('should expand all content links when expandContentLinks are set to true', async () => {

--- a/test/getContentList.tests.ts
+++ b/test/getContentList.tests.ts
@@ -295,11 +295,6 @@ describe('getContentList:', () => {
 			referenceName: 'posts',
 			locale: 'en-us',
 			filterString: `contentID[eq]15 or properties.referenceName[like]"posts"`
-			// [
-			// 	{ property: 'contentID', operator: api.types.FilterOperators.EQUAL_TO, value: '15' },
-			// 	{ property: 'properties.referenceName', operator: api.types.FilterOperators.LIKE, value: 'posts' },
-			// ],
-			// filtersLogicOperator: api.types.FilterLogicOperators.OR,
 		});
 		expect(contentList.items[0].contentID).toBe(16);
 		expect(contentList.items[3].contentID).toBe(15);


### PR DESCRIPTION
We need to be able to pass a filter to `getContentList` as a string so that we can do more complex filtering with brackets.